### PR TITLE
Correctly add spaces around @ arguments

### DIFF
--- a/src/me/zombie_striker/psudocommands/CommandUtils.java
+++ b/src/me/zombie_striker/psudocommands/CommandUtils.java
@@ -222,7 +222,9 @@ public class CommandUtils {
 			ents[0] = entity;
 		} else {
 			ents = new Entity[1];
-			ents[0] = Bukkit.getPlayer(arg);
+			@SuppressWarnings("deprecation") /* Not storing player */
+			Player tmp = Bukkit.getPlayer(arg);
+			ents[0] = tmp;
 		}
 		return ents;
 	}

--- a/src/me/zombie_striker/psudocommands/Main.java
+++ b/src/me/zombie_striker/psudocommands/Main.java
@@ -84,6 +84,9 @@ public class Main extends JavaPlugin {
 								break;
 							}
 							sb.append((e[j].getCustomName() != null ? e[j].getCustomName() : e[j].getName()));
+							if (i + 1 < args.length) {
+								sb.append(" ");
+							}
 							temps.add(sb);
 						}
 						if (!works)
@@ -96,7 +99,9 @@ public class Main extends JavaPlugin {
 					} else {
 						cmd.append(args[i]);
 					}
-					cmd.append(" ");
+					if (i + 1 < args.length) {
+						cmd.append(" ");
+					}
 				}
 				if (temps.size() > 0) {
 					cmds.addAll(temps);

--- a/src/me/zombie_striker/psudocommands/Main.java
+++ b/src/me/zombie_striker/psudocommands/Main.java
@@ -50,7 +50,7 @@ public class Main extends JavaPlugin {
 				senders[0]=sender;
 			}
 			if (senders[0] == null) {
-				sender.sendMessage("The sender is null. Chose a valid player or \"Console\"");
+				sender.sendMessage("The sender is null. Choose a valid player or \"Console\"");
 				return true;
 			}
 			for (CommandSender issue :senders) {

--- a/src/me/zombie_striker/psudocommands/Main.java
+++ b/src/me/zombie_striker/psudocommands/Main.java
@@ -41,9 +41,12 @@ public class Main extends JavaPlugin {
 					senders[0] = Bukkit.getConsoleSender();
 				else if (args[0].contains("@")) {
 					senders = CommandUtils.getTargets(sender, args[0]);
-				} else
-					senders[0] = Bukkit.getPlayer(args[0]);
-			}else {
+				} else {
+					@SuppressWarnings("deprecation") /* Not storing player */
+					Player tmp = Bukkit.getPlayer(args[0]);
+					senders[0] = tmp;
+				}
+			} else {
 				senders[0]=sender;
 			}
 			if (senders[0] == null) {


### PR DESCRIPTION
* For branched arguments, there was no space added @, causing the command to error. (E.g. `tell @a hi` turning into `tell <player>hi` instead of `tell <player> hi`)

* Non-branched commands always had a space added at the very end.

Also suppressed the bukkit getPlayer(String) warning, as they're not applicable, and fixed a typo in an error message.